### PR TITLE
feat: allow overriding actor app name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,14 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "01:00"
-    timezone: America/Los_Angeles
-  open-pull-requests-limit: 10
-  reviewers:
-  - tianhaoz95
-  labels:
-  - automated dependency update
-  - patch
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "01:00"
+      timezone: America/Los_Angeles
+    open-pull-requests-limit: 10
+    reviewers:
+      - tianhaoz95
+    labels:
+      - automated dependency update
+      - patch

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 coverage
 lib
+public
 node_modules
 *.md
 .github/release-drafter.yml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
     "**/.hg": true,
     "**/CVS": true,
     "**/.DS_Store": true
-  }
+  },
+  "editor.tabSize": 2
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2602,8 +2602,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "bytes": {
       "version": "3.1.0",
@@ -10029,7 +10028,6 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -10891,6 +10889,14 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+    },
+    "tslog": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tslog/-/tslog-2.8.0.tgz",
+      "integrity": "sha512-/2dDKosCOtgXIpTpU6JBB38m3aMw7NO+37yMFDxoiWhhw+lisukWMJQRn32TATfrdFa5IxdjCElzhsg6uIa3Rg==",
+      "requires": {
+        "source-map-support": "^0.5.19"
+      }
     },
     "tsutils": {
       "version": "3.17.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "minimatch": "^3.0.4",
     "mustache": "^4.0.1",
     "prettyjson": "^1.2.1",
-    "probot": "^10.2.0"
+    "probot": "^10.2.0",
+    "tslog": "^2.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.13",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "build:docs": "typedoc --out public src",
+    "build:docs": "typedoc --out public src test",
     "build:watch": "tsc && (tsc -w --preserveWatchOutput & nodemon)",
     "dev": "npm run build:watch",
     "start": "probot run ./lib/src/index.js",

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
+import { APP_CHECK_NAME, getAppActorName } from "../utils/config";
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { ReviewEvent, ReviewLookupResult, UserInfo } from "../utils/types";
 /* eslint-enable  @typescript-eslint/no-unused-vars*/
@@ -11,7 +12,6 @@ import {
   composeStatusCheckTitle,
 } from "../utils/msg_composer";
 import { containsNotAllowedFile, ownsAllFiles } from "../utils/rule_matcher";
-import { APP_CHECK_NAME } from "../utils/config";
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Context } from "probot";
 /* eslint-enable  @typescript-eslint/no-unused-vars*/
@@ -209,7 +209,7 @@ const getPreviousReviewIds = async (
         const username = user["login"] as string;
         context.log.info(`Found review left by ${username}`);
         if (
-          username === "approveman[bot]" &&
+          username === getAppActorName() &&
           (review["state"] as string) !== "DISMISSED"
         ) {
           hasReview = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,7 @@ import { Application } from "probot";
 import { maybeApproveChange } from "./core";
 
 export = (app: Application): void => {
-  app.log.info("Starting ApproveMan server ...");
-
+  app.log.info("Start ApproveMan server");
   app.on(
     [
       "pull_request.opened",

--- a/src/utils/config/err_msg.ts
+++ b/src/utils/config/err_msg.ts
@@ -1,0 +1,25 @@
+/**
+ * The error message is thrown when the app is running in a GitHub enterprise
+ * context but the app actor name is not set.
+ */
+export const GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND =
+  "GHE_HOST set but APP_ACTOR_NAME_OVERRIDE is not";
+
+/**
+ * This message is displayed when developers want to start the server
+ * for GitHub Enterprise but forgot to set proper APP_ACTOR_NAME_OVERRIDE
+ * for the app to properly dismiss outdated approvals.
+ */
+export const GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND_DETAILS = `
+  To run ApproveMan for GitHub Enterprise (which is indicated by GHE_HOST set
+  in the environment), please also set APP_ACTOR_NAME_OVERRIDE to help the app
+  properly dismiss outdated approvals since GitHub Enterprise does not name
+  applications the same way as GitHub and ApproveMan currently does not have
+  a way to get the app actor name used.
+
+  For more details, see https://github.com/tianhaoz95/approveman/issues/64.
+
+  In the longer term, there might be a better way to automate the app actor
+  name retrival. For details and progresses, see
+  https://github.com/tianhaoz95/approveman/issues/68.
+`;

--- a/src/utils/config/index.test.ts
+++ b/src/utils/config/index.test.ts
@@ -1,0 +1,46 @@
+import { getAppActorName } from ".";
+
+describe("config tests", () => {
+  const defaultEnv = process.env;
+
+  beforeEach(() => {
+    // Clears the jest cache so that the environment will
+    // not be contaminated between tests.
+    /* eslint-disable */
+    jest.resetModules();
+    /* eslint-enable */
+    // Makes a copy of the current environment variables
+    // to keep the environment variables consistent across
+    // tests.
+    process.env = { ...defaultEnv };
+  });
+
+  afterEach(() => {
+    // Restore the default environment variables
+    // stored in beforeEach.
+    process.env = defaultEnv;
+  });
+
+  test("sanity check", () => {
+    expect(() => {
+      getAppActorName();
+    }).not.toThrow();
+  });
+
+  test("should by default return default name", () => {
+    expect(getAppActorName()).toMatch("approveman[bot");
+  });
+
+  test("GitHub Enterprise without actor name should error out", () => {
+    process.env["GHE_HOST"] = "github.example.com";
+    expect(() => {
+      getAppActorName();
+    }).toThrow();
+  });
+
+  test("GitHub Enterprise with actor name should return that actor name", () => {
+    process.env["GHE_HOST"] = "github.example.com";
+    process.env["APP_ACTOR_NAME_OVERRIDE"] = "testapp";
+    expect(getAppActorName()).toMatch("testapp");
+  });
+});

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -10,6 +10,11 @@ export const NOT_ALLOWED_FILES = ["**/.github/**/*"];
  */
 export const APPROVEMAN_CONFIG_FILENAME = ".github/approveman.yml";
 
+/**
+ * The default app actor name, this is assigned by GitHub
+ * Marketplace, so all GitHub user will see this.
+ * By contrast, GitHub Enterprise users will see otherwise.
+ */
 export const DEFAULT_APP_ACTOR_NAME = "approveman[bot]";
 
 /**

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -31,9 +31,9 @@ export const getAppActorName = (): string => {
     if (process.env.APP_ACTOR_NAME_OVERRIDE) {
       /* eslint-disable no-magic-numbers */
       if (process.env.APP_ACTOR_NAME_OVERRIDE.length === 0) {
+        /* eslint-enable no-magic-numbers */
         throw Error("Cannot set override app actor name to an empty string");
       }
-      /* eslint-enable no-magic-numbers */
       return process.env.APP_ACTOR_NAME_OVERRIDE;
     } else {
       throw Error(GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND);

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -29,10 +29,11 @@ export const DEFAULT_APP_ACTOR_NAME = "approveman[bot]";
 export const getAppActorName = (): string => {
   if (process.env.GHE_HOST) {
     if (process.env.APP_ACTOR_NAME_OVERRIDE) {
-      // eslint-disable-next-line no-magic-numbers
+      /* eslint-disable no-magic-numbers */
       if (process.env.APP_ACTOR_NAME_OVERRIDE.length === 0) {
         throw Error("Cannot set override app actor name to an empty string");
       }
+      /* eslint-enable no-magic-numbers */
       return process.env.APP_ACTOR_NAME_OVERRIDE;
     } else {
       throw Error(GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND);

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -29,11 +29,6 @@ export const DEFAULT_APP_ACTOR_NAME = "approveman[bot]";
 export const getAppActorName = (): string => {
   if (process.env.GHE_HOST) {
     if (process.env.APP_ACTOR_NAME_OVERRIDE) {
-      /* eslint-disable no-magic-numbers */
-      if (process.env.APP_ACTOR_NAME_OVERRIDE.length === 0) {
-        /* eslint-enable no-magic-numbers */
-        throw Error("Cannot set override app actor name to an empty string");
-      }
       return process.env.APP_ACTOR_NAME_OVERRIDE;
     } else {
       throw Error(GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND);

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -1,3 +1,5 @@
+import { GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND } from "./err_msg";
+
 export const APP_CHECK_NAME = "ApproveMan";
 
 export const NOT_ALLOWED_FILES = ["**/.github/**/*"];
@@ -7,3 +9,34 @@ export const NOT_ALLOWED_FILES = ["**/.github/**/*"];
  * configuration validation.
  */
 export const APPROVEMAN_CONFIG_FILENAME = ".github/approveman.yml";
+
+export const DEFAULT_APP_ACTOR_NAME = "approveman[bot]";
+
+/**
+ * Resolve the app actor name that should be used.
+ *
+ * The app installed on GitHub, no matter with personal or
+ * orgranization account will have the app actor name as
+ * {@link DEFAULT_APP_ACTOR_NAME}, but GitHub enterprise
+ * will have a different name since the app is running in
+ * a enterprise defined environment.
+ *
+ * TODO(tianhaoz95): try to see if the actor name can be
+ * detected automatically to some degree.
+ *
+ * @returns The resolved app actor name.
+ */
+export const getAppActorName = (): string => {
+  if (process.env.GHE_HOST) {
+    if (process.env.APP_ACTOR_NAME_OVERRIDE) {
+      // eslint-disable-next-line no-magic-numbers
+      if (process.env.APP_ACTOR_NAME_OVERRIDE.length === 0) {
+        throw Error("Cannot set override app actor name to an empty string");
+      }
+      return process.env.APP_ACTOR_NAME_OVERRIDE;
+    } else {
+      throw Error(GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND);
+    }
+  }
+  return DEFAULT_APP_ACTOR_NAME;
+};

--- a/src/utils/health_check/index.test.ts
+++ b/src/utils/health_check/index.test.ts
@@ -1,0 +1,65 @@
+import { healthCheck } from ".";
+
+describe("health check tests", () => {
+  const defaultEnv = process.env;
+
+  beforeEach(() => {
+    // Clears the jest cache so that the environment will
+    // not be contaminated between tests.
+    /* eslint-disable */
+    jest.resetModules();
+    /* eslint-enable */
+    // Makes a copy of the current environment variables
+    // to keep the environment variables consistent across
+    // tests.
+    process.env = { ...defaultEnv };
+  });
+
+  afterEach(() => {
+    // Restore the default environment variables
+    // stored in beforeEach.
+    process.env = defaultEnv;
+  });
+
+  test("sanity check", () => {
+    expect(() => {
+      healthCheck(
+        (msg) => {
+          console.log(msg);
+        },
+        (msg) => {
+          console.error(msg);
+        },
+      );
+    }).not.toThrow();
+  });
+
+  test("fails GitHub Enterprise without actor name", () => {
+    process.env["GHE_HOST"] = "github.example.com";
+    expect(() => {
+      healthCheck(
+        (msg) => {
+          console.log(msg);
+        },
+        (msg) => {
+          console.error(msg);
+        },
+      );
+    }).toThrow();
+  });
+
+  test("allows GitHub Enterprise with actor name", () => {
+    process.env["GHE_HOST"] = "github.example.com";
+    process.env["APP_ACTOR_NAME_OVERRIDE"] = "testapp";
+    expect(() => {
+      healthCheck(
+        (msg) => {
+          console.log(msg);
+        },
+        (msg) => {
+          console.error(msg);
+        },
+      );
+    }).not.toThrow();
+  });
+});

--- a/src/utils/health_check/index.test.ts
+++ b/src/utils/health_check/index.test.ts
@@ -1,7 +1,9 @@
+import { Logger } from "tslog";
 import { healthCheck } from ".";
 
 describe("health check tests", () => {
   const defaultEnv = process.env;
+  const log: Logger = new Logger();
 
   beforeEach(() => {
     // Clears the jest cache so that the environment will
@@ -25,10 +27,10 @@ describe("health check tests", () => {
     expect(() => {
       healthCheck(
         (msg) => {
-          console.log(msg);
+          log.info(msg);
         },
         (msg) => {
-          console.error(msg);
+          log.error(msg);
         },
       );
     }).not.toThrow();
@@ -39,10 +41,10 @@ describe("health check tests", () => {
     expect(() => {
       healthCheck(
         (msg) => {
-          console.log(msg);
+          log.info(msg);
         },
         (msg) => {
-          console.error(msg);
+          log.error(msg);
         },
       );
     }).toThrow();
@@ -54,10 +56,10 @@ describe("health check tests", () => {
     expect(() => {
       healthCheck(
         (msg) => {
-          console.log(msg);
+          log.info(msg);
         },
         (msg) => {
-          console.error(msg);
+          log.error(msg);
         },
       );
     }).not.toThrow();

--- a/src/utils/health_check/index.ts
+++ b/src/utils/health_check/index.ts
@@ -1,0 +1,30 @@
+import {
+  GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND,
+  GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND_DETAILS,
+} from "../config/err_msg";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Application } from "probot";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+/**
+ * Checks if the environment is OK for the app to boot up.
+ *
+ * This is not used because there is nothing to get called
+ * synchronously by Probot to check the health status. I've
+ * opened a issue to request this feature in the Probot
+ * repository. For details and progresses, see:
+ * https://github.com/probot/probot/issues/1340
+ *
+ * @param app The Probot app.
+ * @returns Nothing, but errors out if health check
+ * does not pass.
+ */
+export const healthCheck = (app: Application): void => {
+  app.log.info("Start health check");
+  if (process.env.GHE_HOST) {
+    if (process.env.APP_ACTOR_NAME_OVERRIDE) {
+      app.log.error(GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND_DETAILS);
+      throw Error(GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND);
+    }
+  }
+};

--- a/src/utils/health_check/index.ts
+++ b/src/utils/health_check/index.ts
@@ -2,9 +2,6 @@ import {
   GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND,
   GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND_DETAILS,
 } from "../config/err_msg";
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import { Application } from "probot";
-/* eslint-enable @typescript-eslint/no-unused-vars */
 
 /**
  * Checks if the environment is OK for the app to boot up.
@@ -19,11 +16,14 @@ import { Application } from "probot";
  * @returns Nothing, but errors out if health check
  * does not pass.
  */
-export const healthCheck = (app: Application): void => {
-  app.log.info("Start health check");
+export const healthCheck = (
+  log: (msg: string) => void,
+  err: (msg: string) => void,
+): void => {
+  log("Start health check");
   if (process.env.GHE_HOST) {
-    if (process.env.APP_ACTOR_NAME_OVERRIDE) {
-      app.log.error(GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND_DETAILS);
+    if (!process.env.APP_ACTOR_NAME_OVERRIDE) {
+      err(GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND_DETAILS);
       throw Error(GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND);
     }
   }

--- a/test/enterprise.test.ts
+++ b/test/enterprise.test.ts
@@ -9,16 +9,13 @@ import {
   checkStartedStatus,
   checkSuccessStatus,
 } from "./utils/status";
-import {
-  prOpenedPayload,
-  prReopenedPayload,
-  prSynchronizePayload,
-} from "./fixtures/payloads/basic";
+import { prOpenedPayload, prReopenedPayload } from "./fixtures/payloads/basic";
 import { setConfigNotFound, setConfigToBasic } from "./utils/config";
 import { StatusCodes } from "http-status-codes";
 import { TEST_TIMEOUT } from "./utils/jest";
 import approvemanApp from "../src";
 import fs from "fs";
+import { getAppActorName } from "../src/utils/config";
 import { getGitHubAPIEndpoint } from "./utils/endpoint";
 import nock from "nock";
 import path from "path";
@@ -57,18 +54,6 @@ describe("Approveman tests", () => {
     // tests.
     process.env = { ...defaultEnv };
     nock.disableNetConnect();
-    probot = new Probot({
-      Octokit: ProbotOctokit.defaults({
-        retry: { enabled: false },
-        throttle: { enabled: false },
-      }),
-      githubToken: "test",
-      id: 1,
-      privateKey: mockCert,
-    });
-    const app = probot.load(approvemanApp);
-    app.log.info("Test app constructed");
-    checkStartedStatus();
   });
 
   afterEach(() => {
@@ -79,7 +64,44 @@ describe("Approveman tests", () => {
     nock.enableNetConnect();
   });
 
-  test("receive PR reopened", async () => {
+  test("enterprise without actor name should fail early", async () => {
+    process.env["GHE_HOST"] = "github.example.com";
+    probot = new Probot({
+      Octokit: ProbotOctokit.defaults({
+        retry: { enabled: false },
+        throttle: { enabled: false },
+      }),
+      githubToken: "test",
+      id: 1,
+      privateKey: mockCert,
+    });
+    probot.load(approvemanApp);
+    checkStartedStatus();
+    checkCrashStatus();
+    nock(getGitHubAPIEndpoint())
+      .get("/repos/tianhaoz95/approveman-test/pulls/1/files")
+      .reply(StatusCodes.OK, [{ filename: "playground/tianhaoz95/test.md" }]);
+    await probot.receive({
+      id: "test_id",
+      name: "pull_request",
+      payload: prReopenedPayload,
+    });
+  });
+
+  test("enterprise functions properly after actor name set", async () => {
+    process.env["GHE_HOST"] = "github.example.com";
+    process.env["APP_ACTOR_NAME_OVERRIDE"] = "test_actor_name";
+    probot = new Probot({
+      Octokit: ProbotOctokit.defaults({
+        retry: { enabled: false },
+        throttle: { enabled: false },
+      }),
+      githubToken: "test",
+      id: 1,
+      privateKey: mockCert,
+    });
+    probot.load(approvemanApp);
+    checkStartedStatus();
     setConfigNotFound();
     checkApproved();
     checkSuccessStatus();
@@ -93,51 +115,20 @@ describe("Approveman tests", () => {
     });
   });
 
-  test("receive PR synchronize", async () => {
-    setConfigNotFound();
-    checkApproved();
-    checkSuccessStatus();
-    nock(getGitHubAPIEndpoint())
-      .get("/repos/tianhaoz95/approveman-test/pulls/1/files")
-      .reply(StatusCodes.OK, [{ filename: "playground/tianhaoz95/test.md" }]);
-    await probot.receive({
-      id: "test_id",
-      name: "pull_request",
-      payload: prSynchronizePayload,
+  test("enterprise dismisses approvals properly after actor name set", async () => {
+    process.env["GHE_HOST"] = "github.example.com";
+    process.env["APP_ACTOR_NAME_OVERRIDE"] = "test_actor_name";
+    probot = new Probot({
+      Octokit: ProbotOctokit.defaults({
+        retry: { enabled: false },
+        throttle: { enabled: false },
+      }),
+      githubToken: "test",
+      id: 1,
+      privateKey: mockCert,
     });
-  });
-
-  test("receive PR opened", async () => {
-    setConfigNotFound();
-    checkApproved();
-    checkSuccessStatus();
-    nock(getGitHubAPIEndpoint())
-      .get("/repos/tianhaoz95/approveman-test/pulls/1/files")
-      .reply(StatusCodes.OK, [{ filename: "playground/tianhaoz95/test.md" }]);
-    await probot.receive({
-      id: "test_id",
-      name: "pull_request",
-      payload: prOpenedPayload,
-    });
-  });
-
-  test("read config", async () => {
-    setConfigToBasic("basic");
-    checkApproved();
-    checkSuccessStatus();
-    nock(getGitHubAPIEndpoint())
-      .get("/repos/tianhaoz95/approveman-test/pulls/1/files")
-      .reply(StatusCodes.OK, [
-        { filename: "docs/personal/tianhaoz95/test.md" },
-      ]);
-    await probot.receive({
-      id: "test_id",
-      name: "pull_request",
-      payload: prOpenedPayload,
-    });
-  });
-
-  test("rules not satisfied", async () => {
+    probot.load(approvemanApp);
+    checkStartedStatus();
     setConfigToBasic("basic");
     checkSuccessStatus();
     nock(getGitHubAPIEndpoint())
@@ -145,33 +136,11 @@ describe("Approveman tests", () => {
       .reply(StatusCodes.OK, [{ filename: "some/random/file.md" }]);
     setSinglePreviousReview();
     verifyReviewDismissed();
+    expect(getAppActorName()).not.toMatch("approveman[bot]");
     await probot.receive({
       id: "test_id",
       name: "pull_request",
       payload: prOpenedPayload,
-    });
-  });
-
-  test("block not allowed files", async () => {
-    checkSuccessStatus();
-    nock(getGitHubAPIEndpoint())
-      .get("/repos/tianhaoz95/approveman-test/pulls/1/files")
-      .reply(StatusCodes.OK, [{ filename: ".github/config.yml" }]);
-    setSinglePreviousReview();
-    verifyReviewDismissed();
-    await probot.receive({
-      id: "test_id",
-      name: "pull_request",
-      payload: prOpenedPayload,
-    });
-  });
-
-  test("handle unknown error elegantly", async () => {
-    checkCrashStatus();
-    await probot.receive({
-      id: "test_id",
-      name: "pull_request",
-      payload: "???",
     });
   });
 });

--- a/test/enterprise.test.ts
+++ b/test/enterprise.test.ts
@@ -48,7 +48,9 @@ describe("Approveman tests", () => {
   beforeEach(() => {
     // Clears the jest cache so that the environment will
     // not be contaminated between tests.
+    /* eslint-disable */
     jest.resetModules();
+    /* eslint-enable */
     // Makes a copy of the current environment variables
     // to keep the environment variables consistent across
     // tests.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,7 +51,9 @@ describe("Approveman tests", () => {
   beforeEach(() => {
     // Clears the jest cache so that the environment will
     // not be contaminated between tests.
+    /* eslint-disable */
     jest.resetModules();
+    /* eslint-enable */
     // Makes a copy of the current environment variables
     // to keep the environment variables consistent across
     // tests.

--- a/test/utils/auth.ts
+++ b/test/utils/auth.ts
@@ -1,8 +1,9 @@
 import { StatusCodes } from "http-status-codes";
+import { getGitHubAPIEndpoint } from "./endpoint";
 import nock from "nock";
 
 export const returnGitHubToken = (): void => {
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .post("/app/installations/1/access_tokens")
     .reply(StatusCodes.OK, { token: "test" });
 };

--- a/test/utils/config.ts
+++ b/test/utils/config.ts
@@ -1,5 +1,6 @@
 import { StatusCodes } from "http-status-codes";
 import fs from "fs";
+import { getGitHubAPIEndpoint } from "./endpoint";
 import nock from "nock";
 import path from "path";
 
@@ -16,7 +17,7 @@ export const setConfigToBasic = (configId: string): void => {
   /* eslint-enable security/detect-non-literal-fs-filename */
   const contentBuf = Buffer.from(rawContent);
   const encodedContent = contentBuf.toString("base64");
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .get("/repos/tianhaoz95/.github/contents/.github%2Fapproveman.yml")
     .reply(StatusCodes.OK, {
       content: encodedContent,
@@ -26,16 +27,16 @@ export const setConfigToBasic = (configId: string): void => {
       size: encodedContent.length,
       type: "file",
     });
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .get("/repos/tianhaoz95/approveman-test/contents/.github%2Fapproveman.yml")
     .reply(StatusCodes.NOT_FOUND);
 };
 
 export const setConfigNotFound = (): void => {
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .get("/repos/tianhaoz95/.github/contents/.github%2Fapproveman.yml")
     .reply(StatusCodes.NOT_FOUND);
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .get("/repos/tianhaoz95/approveman-test/contents/.github%2Fapproveman.yml")
     .reply(StatusCodes.NOT_FOUND);
 };

--- a/test/utils/endpoint.ts
+++ b/test/utils/endpoint.ts
@@ -1,0 +1,19 @@
+/**
+ * Get the GitHub API endpoint the nock should mimic
+ * for testing since the endpoint for GitHub and GitHub
+ * Enterprise are different, but other things works the
+ * same.
+ *
+ * @returns The endpoint in string form.
+ */
+export const getGitHubAPIEndpoint = (): string => {
+  if (process.env.GHE_HOST) {
+    if (!RegExp("^github\\..*\\.com$").test(process.env.GHE_HOST)) {
+      throw Error(
+        `${process.env.GHE_HOST} is of wrong format, should be github.xxx.com`,
+      );
+    }
+    return `https://${process.env.GHE_HOST}/api/v3`;
+  }
+  return "https://api.github.com";
+};

--- a/test/utils/review.ts
+++ b/test/utils/review.ts
@@ -1,12 +1,14 @@
 import { StatusCodes } from "http-status-codes";
 import { composeReviewDismissalMsg } from "../../src/utils/msg_composer";
+import { getAppActorName } from "../../src/utils/config";
+import { getGitHubAPIEndpoint } from "./endpoint";
 import nock from "nock";
 
 const defaultPullNumber = 1;
 const defaultReviewId = 1;
 
 export const checkApproved = (pullNumber = defaultPullNumber): void => {
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .post(
       `/repos/tianhaoz95/approveman-test/pulls/${pullNumber}/reviews`,
       (body: Record<string, unknown>) => {
@@ -27,7 +29,7 @@ export const checkApproved = (pullNumber = defaultPullNumber): void => {
 export const setPreviousReviews = (
   reviews: Record<string, unknown>[],
 ): void => {
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .get("/repos/tianhaoz95/approveman-test/pulls/1/reviews")
     .reply(StatusCodes.OK, reviews);
 };
@@ -42,7 +44,7 @@ export const setSinglePreviousReview = (): void => {
       id: 1,
       state: "APPROVED",
       user: {
-        login: "approveman[bot]",
+        login: getAppActorName(),
       },
     },
   ]);
@@ -52,7 +54,7 @@ export const verifyReviewDismissed = (
   reviewId = defaultReviewId,
   pullNumber = defaultPullNumber,
 ): void => {
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .put(
       `/repos/tianhaoz95/approveman-test/pulls/${pullNumber}/reviews/${reviewId}/dismissals`,
       (body: Record<string, unknown>) => {

--- a/test/utils/status.ts
+++ b/test/utils/status.ts
@@ -1,9 +1,10 @@
 import { APP_CHECK_NAME } from "../../src/utils/config";
 import { StatusCodes } from "http-status-codes";
+import { getGitHubAPIEndpoint } from "./endpoint";
 import nock from "nock";
 
 export const checkSuccessStatus = (): void => {
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .post(
       "/repos/tianhaoz95/approveman-test/check-runs",
       (body: Record<string, unknown>) => {
@@ -19,7 +20,7 @@ export const checkSuccessStatus = (): void => {
 };
 
 export const checkStartedStatus = (): void => {
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .post(
       "/repos/tianhaoz95/approveman-test/check-runs",
       (body: Record<string, unknown>) => {
@@ -34,7 +35,7 @@ export const checkStartedStatus = (): void => {
 };
 
 export const checkCrashStatus = (): void => {
-  nock("https://api.github.com")
+  nock(getGitHubAPIEndpoint())
     .post(
       "/repos/tianhaoz95/approveman-test/check-runs",
       (body: Record<string, unknown>) => {


### PR DESCRIPTION
This PR adds the feature to override the default app actor name with an environment variable `APP_ACTOR_NAME_OVERRIDE` which used to be hardcoded to "approveman[bot]".

This is useful for GitHub Enterprise users whose app content name is different from the GitHub marketplace. Before the change, GitHub Enterprise users will have trouble dismissing outdated approvals since the name it searches for is "approveman[bot]" (for details on this problem, see #64 ).

This PR also adds a check so that if a GitHub Enterprise user (inferred from `GHE_HOST`) deploys the app without setting `APP_ACTOR_NAME_OVERRIDE` will post a failing status upon any event processed.

This is not ideal because we want to fail the moment the app starts running instead of when an event is received. However, Probot currently doesn't support this kind of health check as far as I know. I have opened an issue for Probot to add this capability into their infra (for details and progress, see https://github.com/probot/probot/issues/1340 ).

@epDHowwD is this going to work for GitHub Enterprise?

This PR closes #64 .

**UPDATE**

To make the linter happy, this also adds logger usage into unit testing, so close #70 .