### PR TITLE
chore: add check group config and minor fixes

### DIFF
--- a/.github/checkgroup.yml
+++ b/.github/checkgroup.yml
@@ -1,0 +1,21 @@
+subprojects:
+  - id: common
+    paths:
+      - "**"
+    checks:
+      - "WIP"
+      - "Semantic Pull Request"
+      - "task-list-completed"
+  - id: documentation
+    paths:
+      - "README.md"
+      - "docs/README.md"
+      - "CONTRIBUTING.md"
+      - "docs/development.md"
+    checks:
+      - "readme-sync"
+  - id: server
+    paths:
+      - "src/**"
+    checks:
+      - "server-test"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,8 +7,7 @@ on:
   schedule:
     - cron: 0 2 * * *
 jobs:
-  test:
-    name: Run tests
+  server-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,13 @@
     "**/CVS": true,
     "**/.DS_Store": true
   },
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "cSpell.words": [
+    "Codacy",
+    "Codecov",
+    "Probot",
+    "lcov",
+    "subprojects",
+    "tianhaoz"
+  ]
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,12 @@ For rare cases where you need to manually test the app behavior, please only ins
 
 ### Tools
 
+#### Prerequisites
+
+-   It is recommended to develop ApproveMan on a Linux or Mac OS since there are some utility bash scripts that help save you time. Powershell scripts are available but they are less maintained compared with bash scripts. If you happen to have a windows machine, you can use WSL2.
+
+#### Editor
+
 The recommended editor for development is Visual Studio Code since the project has a corresponding configuration file that should work out-of-box.
 
 #### Recommended VS Code extensions
@@ -27,6 +33,8 @@ The recommended editor for development is Visual Studio Code since the project h
 -   [GitHub issues (Optional)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.github-issues-prs)
 
 ## Workflow
+
+The workflow is pretty much taken straight from the Probot project.
 
 ### Issues and PRs
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,12 @@ For rare cases where you need to manually test the app behavior, please only ins
 
 ### Tools
 
+#### Prerequisites
+
+-   It is recommended to develop ApproveMan on a Linux or Mac OS since there are some utility bash scripts that help save you time. Powershell scripts are available but they are less maintained compared with bash scripts. If you happen to have a windows machine, you can use WSL2.
+
+#### Editor
+
 The recommended editor for development is Visual Studio Code since the project has a corresponding configuration file that should work out-of-box.
 
 #### Recommended VS Code extensions
@@ -27,6 +33,8 @@ The recommended editor for development is Visual Studio Code since the project h
 -   [GitHub issues (Optional)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.github-issues-prs)
 
 ## Workflow
+
+The workflow is pretty much taken straight from the Probot project.
 
 ### Issues and PRs
 


### PR DESCRIPTION
The check group app is another convenient GitHub app that bundles checks based on the sub-projects they belong to. Once proven to be reliable, we can only run necessary checks for each pull request instead of run all of them wasting a ton of time and resources.