### PR TITLE
fix: complete status omit start time

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "prettier": "prettier --check .",
     "prettier:format": "prettier --write .",
     "format": "npm run prettier:format && npm run eslint:format",
-    "test": "jest && npm run eslint",
+    "test": "npm run test:silent",
+    "test:debug": "jest && npm run eslint",
     "test:silent": "LOG_LEVEL=warn jest && npm run eslint",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage"
   },

--- a/src/core/create_status.ts
+++ b/src/core/create_status.ts
@@ -1,0 +1,69 @@
+import { APP_CHECK_NAME } from "../utils/config";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Context } from "probot";
+/* eslint-enable  @typescript-eslint/no-unused-vars*/
+import { StatusCodes } from "http-status-codes";
+
+/**
+ * Creates a check in the pull request.
+ *
+ * @param context The request context from Probot core.
+ * @param conclusion The conclusion of the run.
+ * @param status The status of the run.
+ * @param title The title that shows up when user clicks on the check.
+ * @param summary The summary that shows up under the title.
+ * @param details The details that shows up under the summary.
+ * @param startTime The string time that the run started.
+ */
+export const createStatus = async (
+  context: Context,
+  conclusion:
+    | "success"
+    | "failure"
+    | "neutral"
+    | "cancelled"
+    | "timed_out"
+    | "action_required"
+    | undefined,
+  status: "in_progress" | "completed" | "queued",
+  title: string,
+  summary: string,
+  details: string,
+  startTime: string,
+): Promise<void> => {
+  /* eslint-disable */
+  const completedAt: string | undefined = conclusion
+    ? new Date().toISOString()
+    : undefined;
+  const startedAt: string | undefined =
+    status === "in_progress" ? startTime : undefined;
+  /* eslint-enable */
+  const statusOptions = context.repo({
+    "completed_at": completedAt,
+    conclusion,
+    "head_sha": context.payload.pull_request.head.sha,
+    "name": APP_CHECK_NAME,
+    "output": {
+      summary,
+      "text": details,
+      title,
+    },
+    "request": {
+      "retries": 3,
+      "retryAfter": 3,
+    },
+    "started_at": startedAt,
+    status,
+  });
+  const response = await context.github.checks.create(statusOptions);
+  context.log.info(
+    `Create passing status finished with status ${response.status}`,
+  );
+  if (response.status !== StatusCodes.CREATED) {
+    context.log.error(
+      `Create passing status failed with status ${
+        response.status
+      } and error: ${JSON.stringify(response.data)}`,
+    );
+  }
+};

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,3 @@
-import { APP_CHECK_NAME, getAppActorName } from "../utils/config";
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { ReviewEvent, ReviewLookupResult, UserInfo } from "../utils/types";
 /* eslint-enable  @typescript-eslint/no-unused-vars*/
@@ -16,6 +15,8 @@ import { containsNotAllowedFile, ownsAllFiles } from "../utils/rule_matcher";
 import { Context } from "probot";
 /* eslint-enable  @typescript-eslint/no-unused-vars*/
 import { StatusCodes } from "http-status-codes";
+import { createStatus } from "./create_status";
+import { getAppActorName } from "../utils/config";
 import { getOwnershipRules } from "../utils/config_parser";
 
 const getPullAuthor = (context: Context): string => {
@@ -46,68 +47,6 @@ const approveChange = async (context: Context): Promise<void> => {
     }
   } catch (err) {
     context.log.error(`Approve change failed with: ${JSON.stringify(err)}`);
-  }
-};
-
-/**
- * Creates a check in the pull request.
- *
- * @param context The request context from Probot core.
- * @param conclusion The conclusion of the run.
- * @param status The status of the run.
- * @param title The title that shows up when user clicks on the check.
- * @param summary The summary that shows up under the title.
- * @param details The details that shows up under the summary.
- * @param startTime The string time that the run started.
- */
-export const createStatus = async (
-  context: Context,
-  conclusion:
-    | "success"
-    | "failure"
-    | "neutral"
-    | "cancelled"
-    | "timed_out"
-    | "action_required"
-    | undefined,
-  status: "in_progress" | "completed" | "queued",
-  title: string,
-  summary: string,
-  details: string,
-  startTime: string,
-): Promise<void> => {
-  /* eslint-disable */
-  const completedAt: string | undefined = conclusion
-    ? new Date().toISOString()
-    : undefined;
-  /* eslint-enable */
-  const statusOptions = context.repo({
-    "completed_at": completedAt,
-    conclusion,
-    "head_sha": context.payload.pull_request.head.sha,
-    "name": APP_CHECK_NAME,
-    "output": {
-      summary,
-      "text": details,
-      title,
-    },
-    "request": {
-      "retries": 3,
-      "retryAfter": 3,
-    },
-    "started_at": startTime,
-    status,
-  });
-  const response = await context.github.checks.create(statusOptions);
-  context.log.info(
-    `Create passing status finished with status ${response.status}`,
-  );
-  if (response.status !== StatusCodes.CREATED) {
-    context.log.error(
-      `Create passing status failed with status ${
-        response.status
-      } and error: ${JSON.stringify(response.data)}`,
-    );
   }
 };
 

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -33,9 +33,17 @@ export const DEFAULT_APP_ACTOR_NAME = "approveman[bot]";
  */
 export const getAppActorName = (): string => {
   if (process.env.GHE_HOST) {
+    /* istanbul ignore else */
     if (process.env.APP_ACTOR_NAME_OVERRIDE) {
       return process.env.APP_ACTOR_NAME_OVERRIDE;
     } else {
+      /**
+       * Since there is already a static health check at
+       * the beginning of the server boot up. This branch
+       * will never run in practice. However, it's left
+       * here for some unknown situations since the host
+       * environment can get weird sometimes.
+       */
       throw Error(GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND);
     }
   }

--- a/test/utils/status.ts
+++ b/test/utils/status.ts
@@ -13,6 +13,8 @@ export const checkSuccessStatus = (): void => {
           name: APP_CHECK_NAME,
           status: "completed",
         });
+        expect(body["started_at"]).not.toBeDefined();
+        expect(body["completed_at"]).toBeDefined();
         return true;
       },
     )
@@ -28,6 +30,8 @@ export const checkStartedStatus = (): void => {
           name: APP_CHECK_NAME,
           status: "in_progress",
         });
+        expect(body["started_at"]).toBeDefined();
+        expect(body["completed_at"]).not.toBeDefined();
         return true;
       },
     )
@@ -44,6 +48,8 @@ export const checkCrashStatus = (): void => {
           name: APP_CHECK_NAME,
           status: "completed",
         });
+        expect(body["started_at"]).not.toBeDefined();
+        expect(body["completed_at"]).toBeDefined();
         return true;
       },
     )


### PR DESCRIPTION
During normal usage, ApproveMan has a good chance posting a never-ending status check probably due to the starting time is posted on each check, even the completed ones which is incorrect.

This PR limits the starting time only to the "in_progress" events and the finishing time to "completed" only.

close #47 