### PR TITLE
chore: add auto approval for Dependabot

### DIFF
--- a/.github/workflows/auto-approval.yml
+++ b/.github/workflows/auto-approval.yml
@@ -1,0 +1,11 @@
+name: Auto Approval
+on: pull_request
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Approve Dependabot updates
+      uses: hmarr/auto-approve-action@v2.0.0
+      if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+      with:
+        github-token: "${{ secrets.USE_GITHUB_TOKEN }}"


### PR DESCRIPTION
Although being optional for now, it's good to have all the reviews fulfilled for the sake of consistency.