### PR TITLE
fix: support dot files and directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Note:
 
 -   The default config contains `playground/{{username}}/**/*` if no config file is provided in the repository.
 -   All pull requests that modify files within `.github` the directory is denied regardless of the rules in the configuration for safety.
+-   The globstar matches only the directories. More specifically, if you want all Markdown files in a directory, please use `playground/{{username}}/**/*.md` instead of `playground/{{username}}/**.md` which might work with some of the matching package variances.
 
 Here is an example of how it works:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ Note:
 
 -   The default config contains `playground/{{username}}/**/*` if no config file is provided in the repository.
 -   All pull requests that modify files within `.github` the directory is denied regardless of the rules in the configuration for safety.
+-   The globstar matches only the directories. More specifically, if you want all Markdown files in a directory, please use `playground/{{username}}/**/*.md` instead of `playground/{{username}}/**.md` which might work with some of the matching package variances.
 
 Here is an example of how it works:
 

--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -1,4 +1,7 @@
 import { GITHUB_ENTERPRISE_APP_ACTOR_NOT_FOUND } from "./err_msg";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import minimatch from "minimatch";
+/* eslint-enable @typescript-eslint/no-unused-vars */
 
 export const APP_CHECK_NAME = "ApproveMan";
 
@@ -48,4 +51,12 @@ export const getAppActorName = (): string => {
     }
   }
   return DEFAULT_APP_ACTOR_NAME;
+};
+
+/**
+ * The minimatch option that should be used to match
+ * user defined files against pull requests.
+ */
+export const MATCH_OPTIONS: minimatch.IOptions = {
+  dot: true,
 };

--- a/src/utils/rule_matcher/index.test.ts
+++ b/src/utils/rule_matcher/index.test.ts
@@ -48,7 +48,7 @@ describe("Rule matcher tests", () => {
   test("match rule filters correct filenames", () => {
     expect(
       matchRule(
-        { name: "test rule", path: "playground/{{username}}/**.md" },
+        { name: "test rule", path: "playground/{{username}}/**/*.md" },
         "playground/tianhaoz95/test.md",
         { username: "tianhaoz95" },
         null,
@@ -56,12 +56,34 @@ describe("Rule matcher tests", () => {
     ).toBe(true);
     expect(
       matchRule(
-        { name: "test rule", path: "playground/{{username}}/**.md" },
+        { name: "test rule", path: "playground/{{username}}/**/*.md" },
         "other_location/tianhaoz95/test.md",
         { username: "tianhaoz95" },
         null,
       ),
     ).toBe(false);
+  });
+
+  test("should allow nested files to match", () => {
+    expect(
+      matchRule(
+        { name: "test rule", path: "playground/{{username}}/**/*.md" },
+        "playground/tianhaoz95/projects/project/test.md",
+        { username: "tianhaoz95" },
+        null,
+      ),
+    ).toBe(true);
+  });
+
+  test("should allow shallow files to match nested rule", () => {
+    expect(
+      matchRule(
+        { name: "test rule", path: "playground/{{username}}/**/*.md" },
+        "playground/tianhaoz95/test.md",
+        { username: "tianhaoz95" },
+        null,
+      ),
+    ).toBe(true);
   });
 
   test("correctly identify ApproveMan config", () => {

--- a/src/utils/rule_matcher/index.test.ts
+++ b/src/utils/rule_matcher/index.test.ts
@@ -75,6 +75,28 @@ describe("Rule matcher tests", () => {
     ).toBe(true);
   });
 
+  test("should allow nested dot directory to match", () => {
+    expect(
+      matchRule(
+        { name: "test rule", path: "playground/{{username}}/**/*" },
+        "playground/tianhaoz95/projects/.project/main.cc",
+        { username: "tianhaoz95" },
+        null,
+      ),
+    ).toBe(true);
+  });
+
+  test("should allow nested dot file to match", () => {
+    expect(
+      matchRule(
+        { name: "test rule", path: "playground/{{username}}/**/*" },
+        "playground/tianhaoz95/projects/project/.gitignore",
+        { username: "tianhaoz95" },
+        null,
+      ),
+    ).toBe(true);
+  });
+
   test("should allow shallow files to match nested rule", () => {
     expect(
       matchRule(

--- a/src/utils/rule_matcher/index.ts
+++ b/src/utils/rule_matcher/index.ts
@@ -1,4 +1,8 @@
-import { APPROVEMAN_CONFIG_FILENAME, NOT_ALLOWED_FILES } from "../config";
+import {
+  APPROVEMAN_CONFIG_FILENAME,
+  MATCH_OPTIONS,
+  NOT_ALLOWED_FILES,
+} from "../config";
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { DirectoryMatchingRule, UserInfo } from "../types";
 /* eslint-enable @typescript-eslint/no-unused-vars */
@@ -24,7 +28,7 @@ export const matchRule = (
 ): boolean => {
   const renderedRule = Mustache.render(rule.path, info);
   context?.log.info(`Rendered rules to ${renderedRule}`);
-  const isMatch = minimatch(filename, renderedRule);
+  const isMatch = minimatch(filename, renderedRule, MATCH_OPTIONS);
   context?.log.info(
     `File ${filename} and rule ${renderedRule} matching result is ${isMatch}`,
   );
@@ -49,7 +53,7 @@ export const containsApproveManConfig = (filenames: string[]): boolean => {
 export const isAllowedFile = (filename: string): boolean => {
   let isAllowed = true;
   NOT_ALLOWED_FILES.forEach((notAllowedFile) => {
-    if (minimatch(filename, notAllowedFile)) {
+    if (minimatch(filename, notAllowedFile, MATCH_OPTIONS)) {
       isAllowed = false;
     }
   });


### PR DESCRIPTION
Previously ** and * doesn't match files that start with a dot. This PR allows that and close #127