### PR TITLE
feat: add global blacklisting capability

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,7 +34,10 @@
     "lcov",
     "qemu",
     "repos",
+    "smee",
     "subprojects",
-    "tianhaoz"
+    "tianhaoz",
+    "tslog",
+    "typedoc"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -97,6 +97,32 @@ npm start # Start the server
 
 After the server is up and running, the rest should be the same as the [GitHub setup](#for-github).
 
+## Available config
+
+The following is a full configuration with default values:
+
+```yml
+ownership_rules:
+  # If files inside .github directory should be allowed.
+  # When it is set of true, rules like .github/workflows/playground__{{username}}-*.yml
+  # can be enable with certain rules.
+  # When it is set of false (default value), a pull request will not be approved
+  # reguardless of rules if any files inside the .github folder is touched.
+  allow_dot_github: false
+  # A list of usernames that should not get their pull requests approved even
+  # validated by rules. This can be used when some users are spotted to abuse
+  # the auto approval and checks in unwanted content that violates the code of
+  # conduct or other policies set by the owner.
+  global_blacklisted_users: []
+  # The rules for matching directory ownership. A pull request is determined to be safe
+  # when all the files modified satisfy at least one of the rules.
+  directory_matching_rules:
+      # The name of the rules that is used mainly for logging.
+    - name: "Default playground rule for prototyping."
+      # The directory that certain user with {{username}} owns.
+      path: "playground/{{username}}/**/*"
+```
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/docs/README.md
+++ b/docs/README.md
@@ -97,6 +97,32 @@ npm start # Start the server
 
 After the server is up and running, the rest should be the same as the [GitHub setup](#for-github).
 
+## Available config
+
+The following is a full configuration with default values:
+
+```yml
+ownership_rules:
+  # If files inside .github directory should be allowed.
+  # When it is set of true, rules like .github/workflows/playground__{{username}}-*.yml
+  # can be enable with certain rules.
+  # When it is set of false (default value), a pull request will not be approved
+  # reguardless of rules if any files inside the .github folder is touched.
+  allow_dot_github: false
+  # A list of usernames that should not get their pull requests approved even
+  # validated by rules. This can be used when some users are spotted to abuse
+  # the auto approval and checks in unwanted content that violates the code of
+  # conduct or other policies set by the owner.
+  global_blacklisted_users: []
+  # The rules for matching directory ownership. A pull request is determined to be safe
+  # when all the files modified satisfy at least one of the rules.
+  directory_matching_rules:
+      # The name of the rules that is used mainly for logging.
+    - name: "Default playground rule for prototyping."
+      # The directory that certain user with {{username}} owns.
+      path: "playground/{{username}}/**/*"
+```
+
 ## Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/package-lock.json
+++ b/package-lock.json
@@ -9215,15 +9215,14 @@
       }
     },
     "remark-lint-list-item-bullet-indent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-list-item-bullet-indent/-/remark-lint-list-item-bullet-indent-2.0.1.tgz",
-      "integrity": "sha512-tozDt9LChG1CvYJnBQH/oh45vNcHYBvg79ogvV0f8MtE/K0CXsM8EpfQ6pImFUdHpBV1op6aF6zPMrB0AkRhcQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-list-item-bullet-indent/-/remark-lint-list-item-bullet-indent-3.0.0.tgz",
+      "integrity": "sha512-X2rleWP8XReC4LXKF7Qi5vYiPJkA4Grx5zxsjHofFrVRz6j0PYOCuz7vsO+ZzMunFMfom6FODnscSWz4zouDVw==",
       "dev": true,
       "requires": {
         "pluralize": "^8.0.0",
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
-        "unist-util-position": "^3.0.0",
         "unist-util-visit": "^2.0.0"
       }
     },
@@ -9254,13 +9253,13 @@
       }
     },
     "remark-lint-no-blockquote-without-marker": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-blockquote-without-marker/-/remark-lint-no-blockquote-without-marker-3.0.1.tgz",
-      "integrity": "sha512-sM953+u0zN90SGd2V5hWcFbacbpaROUslS5Q5F7/aa66/2rAwh6zVnrXc4pf7fFOpj7I9Xa8Aw+uB+3RJWwdrQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-blockquote-without-marker/-/remark-lint-no-blockquote-without-marker-4.0.0.tgz",
+      "integrity": "sha512-Y59fMqdygRVFLk1gpx2Qhhaw5IKOR9T38Wf7pjR07bEFBGUNfcoNVIFMd1TCJfCPQxUyJzzSqfZz/KT7KdUuiQ==",
       "dev": true,
       "requires": {
         "unified-lint-rule": "^1.0.0",
-        "unist-util-generated": "^1.1.0",
+        "unist-util-generated": "^1.0.0",
         "unist-util-position": "^3.0.0",
         "unist-util-visit": "^2.0.0",
         "vfile-location": "^3.0.0"
@@ -9280,9 +9279,9 @@
       }
     },
     "remark-lint-no-heading-content-indent": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-heading-content-indent/-/remark-lint-no-heading-content-indent-2.0.1.tgz",
-      "integrity": "sha512-Jp0zCykGwg13z7XU4VuoFK7DN8bVZ1u3Oqu3hqECsH6LMASb0tW4zcTIc985kcVo3OQTRyb6KLQXL2ltOvppKA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-heading-content-indent/-/remark-lint-no-heading-content-indent-3.0.0.tgz",
+      "integrity": "sha512-yULDoVSIqKylLDfW6mVUbrHlyEWUSFtVFiKc+/BA412xDIhm8HZLUnP+FsuBC0OzbIZ+bO9Txy52WtO3LGnK1A==",
       "dev": true,
       "requires": {
         "mdast-util-heading-style": "^1.0.2",
@@ -9294,9 +9293,9 @@
       }
     },
     "remark-lint-no-inline-padding": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-inline-padding/-/remark-lint-no-inline-padding-2.0.1.tgz",
-      "integrity": "sha512-a36UlPvRrLCgxjjG3YZA9VCDvLBcoBtGNyM04VeCPz+d9hHe+5Fs1C/jL+DRLCH7nff90jJ5C/9b8/LTwhjaWA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-inline-padding/-/remark-lint-no-inline-padding-3.0.0.tgz",
+      "integrity": "sha512-3s9uW3Yux9RFC0xV81MQX3bsYs+UY7nPnRuMxeIxgcVwxQ4E/mTJd9QjXUwBhU9kdPtJ5AalngdmOW2Tgar8Cg==",
       "dev": true,
       "requires": {
         "mdast-util-to-string": "^1.0.2",
@@ -9341,15 +9340,17 @@
       }
     },
     "remark-lint-no-undefined-references": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-undefined-references/-/remark-lint-no-undefined-references-2.0.1.tgz",
-      "integrity": "sha512-tXM2ctFnduC3QcskrIePUajcjtNtBmo2dvlj4aoQJtQy09Soav/rYngb8u/SgERc6Irdmm5s55UAwR9CcSrzVg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-undefined-references/-/remark-lint-no-undefined-references-3.0.0.tgz",
+      "integrity": "sha512-0hzaJS9GuzSQVOeeNdJr/s66LRQOzp618xuOQPYWHcJdd+SCaRTyWbjMrTM/cCI5L1sYjgurp410NkIBQ32Vqg==",
       "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.4",
         "unified-lint-rule": "^1.0.0",
         "unist-util-generated": "^1.1.0",
-        "unist-util-visit": "^2.0.0"
+        "unist-util-position": "^3.1.0",
+        "unist-util-visit": "^2.0.0",
+        "vfile-location": "^3.1.0"
       }
     },
     "remark-lint-no-unused-definitions": {
@@ -9418,38 +9419,27 @@
       }
     },
     "remark-preset-lint-recommended": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/remark-preset-lint-recommended/-/remark-preset-lint-recommended-4.0.1.tgz",
-      "integrity": "sha512-zn+ImQbOVcAQVWLL0R0rFQ2Wy8JyWnuU3mJ8Zh0EVOckglcxByssvTbKqPih3Lh8ogpE38EfnC3a/vshj4Jx6A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-recommended/-/remark-preset-lint-recommended-5.0.0.tgz",
+      "integrity": "sha512-uu+Ab8JCwMMaKvvB0LOWTWtM3uAvJbKQM/oyWCEJqj7lUVNTKZS575Ro5rKM3Dx7kQjjR1iw0e99bpAYTc5xNA==",
       "dev": true,
       "requires": {
-        "remark-lint": "^7.0.0",
+        "remark-lint": "^8.0.0",
         "remark-lint-final-newline": "^1.0.0",
         "remark-lint-hard-break-spaces": "^2.0.0",
-        "remark-lint-list-item-bullet-indent": "^2.0.0",
+        "remark-lint-list-item-bullet-indent": "^3.0.0",
         "remark-lint-list-item-indent": "^2.0.0",
         "remark-lint-no-auto-link-without-protocol": "^2.0.0",
-        "remark-lint-no-blockquote-without-marker": "^3.0.0",
+        "remark-lint-no-blockquote-without-marker": "^4.0.0",
         "remark-lint-no-duplicate-definitions": "^2.0.0",
-        "remark-lint-no-heading-content-indent": "^2.0.0",
-        "remark-lint-no-inline-padding": "^2.0.0",
+        "remark-lint-no-heading-content-indent": "^3.0.0",
+        "remark-lint-no-inline-padding": "^3.0.0",
         "remark-lint-no-literal-urls": "^2.0.0",
         "remark-lint-no-shortcut-reference-image": "^2.0.0",
         "remark-lint-no-shortcut-reference-link": "^2.0.0",
-        "remark-lint-no-undefined-references": "^2.0.0",
+        "remark-lint-no-undefined-references": "^3.0.0",
         "remark-lint-no-unused-definitions": "^2.0.0",
         "remark-lint-ordered-list-marker-style": "^2.0.0"
-      },
-      "dependencies": {
-        "remark-lint": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/remark-lint/-/remark-lint-7.0.1.tgz",
-          "integrity": "sha512-caZXo3qhuBxzvq9JSJFVQ/ERDq/6TJVgWn0KDwKOIJCGOuLXfQhby5XttUq+Rn7kLbNMtvwfWHJlte14LpaeXQ==",
-          "dev": true,
-          "requires": {
-            "remark-message-control": "^6.0.0"
-          }
-        }
       }
     },
     "remark-stringify": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "prettier": "^2.1.2",
     "remark-cli": "^8.0.1",
     "remark-lint": "^8.0.0",
-    "remark-preset-lint-recommended": "^4.0.1",
+    "remark-preset-lint-recommended": "^5.0.0",
     "smee-client": "^1.2.2",
     "standard": "^14.3.1",
     "ts-jest": "^26.4.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "format": "npm run prettier:format && npm run eslint:format",
     "test": "npm run test:silent",
     "test:debug": "jest && npm run eslint",
-    "test:silent": "LOG_LEVEL=warn jest && npm run eslint",
+    "test:silent": "LOG_LEVEL=fatal jest && npm run eslint",
     "test:watch": "LOG_LEVEL=fatal jest --watch --notify --notifyMode=change --coverage"
   },
   "dependencies": {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -13,6 +13,7 @@ import { dismissAllApprovals } from "./dismiss_approval";
 import { getChangedFiles } from "./get_files";
 import { getOwnershipRules } from "../utils/config_parser";
 import { getUserInfo } from "./get_info";
+import { isUserBlacklisted } from "../utils/matchers";
 
 /**
  * Approves a pull request if all the files it contains are owned by the user that
@@ -31,6 +32,19 @@ export const maybeApproveChange = async (context: Context): Promise<void> => {
     );
     const rules = await getOwnershipRules(context);
     context.log.info(`Matching against rules: ${JSON.stringify(rules)}`);
+    const userInfo = getUserInfo(context);
+    // TODO(tianhaoz95): consolidate there precondition checks into
+    // a separate file with name check_prerequisites.ts to make it
+    // more readable.
+    if (isUserBlacklisted(userInfo.username, rules)) {
+      context.log("The user is blacklisted.");
+      await dismissAllApprovals(context);
+      context.log.info("All previous approvals dismissed");
+      // TODO(tianhaoz95): consider making this a failing check
+      // if that makes more sense.
+      await createNeutralStatus(context, startTime);
+      return;
+    }
     if (containsNotAllowedFile(changedFiles, rules)) {
       context.log.info(
         "The user does not own all modified files. " +
@@ -38,7 +52,6 @@ export const maybeApproveChange = async (context: Context): Promise<void> => {
       );
       await dismissAllApprovals(context);
       context.log.info("All previous approvals dismissed");
-      // TODO(tianhaoz95): this should be a neutral check instead.
       await createNeutralStatus(context, startTime);
       return;
     }
@@ -46,7 +59,7 @@ export const maybeApproveChange = async (context: Context): Promise<void> => {
       ownsAllFiles(
         rules.directoryMatchingRules,
         changedFiles,
-        getUserInfo(context),
+        userInfo,
         (msg: string) => {
           context.log.info(msg);
         },

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,8 @@
-import { containsNotAllowedFile, ownsAllFiles } from "../utils/matchers";
+import {
+  containsNotAllowedFile,
+  isUserBlacklisted,
+  ownsAllFiles,
+} from "../utils/matchers";
 import {
   createCrashStatus,
   createNeutralStatus,
@@ -13,7 +17,6 @@ import { dismissAllApprovals } from "./dismiss_approval";
 import { getChangedFiles } from "./get_files";
 import { getOwnershipRules } from "../utils/config_parser";
 import { getUserInfo } from "./get_info";
-import { isUserBlacklisted } from "../utils/matchers";
 
 /**
  * Approves a pull request if all the files it contains are owned by the user that

--- a/src/utils/config_parser/default.ts
+++ b/src/utils/config_parser/default.ts
@@ -8,6 +8,7 @@ export const getDefaultOwnershipRules = (
   const ownershipRules: OwnershipRules = {
     allowDotGitHub: false,
     directoryMatchingRules: [],
+    globalBlacklistedUsers: [],
   };
   if (addPlayground) {
     ownershipRules.directoryMatchingRules.push({

--- a/src/utils/config_parser/index.test.ts
+++ b/src/utils/config_parser/index.test.ts
@@ -1,4 +1,4 @@
-import { getOwnershipRules, parseOwnershipRules } from ".";
+import { getOwnershipRules } from ".";
 import { setConfigNotFound } from "../../../test/utils/config";
 
 describe("config parser tests", () => {
@@ -6,23 +6,5 @@ describe("config parser tests", () => {
     setConfigNotFound();
     const config = await getOwnershipRules(null);
     expect(config).toBeDefined();
-  });
-
-  test("parse basic config", () => {
-    expect(
-      parseOwnershipRules(
-        {
-          "ownership_rules": {
-            "directory_matching_rules": [
-              {
-                "name": "test_rule_0",
-                "path": "playground/{{username}}/*",
-              },
-            ],
-          },
-        },
-        null,
-      ),
-    ).toBeDefined();
   });
 });

--- a/src/utils/config_parser/index.ts
+++ b/src/utils/config_parser/index.ts
@@ -1,48 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { DirectoryMatchingRule, OwnershipRules } from "../types";
-/* eslint-enable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { Context } from "probot";
 /* eslint-enable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { OwnershipRules } from "../types";
+/* eslint-enable @typescript-eslint/no-unused-vars */
 import { getDefaultOwnershipRules } from "./default";
-
-export const parseOwnershipRules = (
-  rules: Record<string, unknown>,
-  context: Context | null,
-): OwnershipRules => {
-  const ownershipRules: OwnershipRules = getDefaultOwnershipRules(false);
-  if ("ownership_rules" in rules) {
-    context?.log.info("Found ownership_rules in the config");
-    const ownershipRulesData = rules["ownership_rules"] as Record<
-      string,
-      unknown
-    >;
-    if ("allow_dot_github" in ownershipRulesData) {
-      ownershipRules.allowDotGitHub = ownershipRulesData[
-        "allow_dot_github"
-      ] as boolean;
-    }
-    if ("directory_matching_rules" in ownershipRulesData) {
-      context?.log.info("Found directory_matching_rules in the config");
-      for (const rule of ownershipRulesData[
-        "directory_matching_rules"
-      ] as Record<string, string>[]) {
-        const directoryMatchingRule: DirectoryMatchingRule = {
-          name: "Default directory matching rule name",
-          path: "Undefined",
-        };
-        if ("name" in rule) {
-          directoryMatchingRule.name = rule["name"];
-        }
-        if ("path" in rule) {
-          directoryMatchingRule.path = rule["path"];
-        }
-        ownershipRules.directoryMatchingRules.push(directoryMatchingRule);
-      }
-    }
-  }
-  return ownershipRules;
-};
+import { parseOwnershipRules } from "./parser";
 
 export const getOwnershipRules = async (
   context: Context | null,

--- a/src/utils/config_parser/parser.test.ts
+++ b/src/utils/config_parser/parser.test.ts
@@ -1,21 +1,48 @@
 import { parseOwnershipRules } from "./parser";
 
+/**
+ * TODO(tianhaoz95): add a test for verifying that the parsed rules are correct.
+ */
 describe("Configuration parser tests", () => {
-  test("parse basic config", () => {
-    expect(
-      parseOwnershipRules(
+  const basicConfig: Record<string, unknown> = {
+    "ownership_rules": {
+      "allow_dot_github": "true",
+      "directory_matching_rules": [
         {
-          "ownership_rules": {
-            "directory_matching_rules": [
-              {
-                "name": "test_rule_0",
-                "path": "playground/{{username}}/*",
-              },
-            ],
-          },
+          "name": "test_rule_0",
+          "path": "test_0/{{username}}/*",
         },
-        null,
-      ),
-    ).toBeDefined();
+        {
+          "name": "test_rule_1",
+          "path": "test_1/{{username}}/*",
+        },
+      ],
+      "global_blacklisted_users": ["bad_user_1", "bad_user_2"],
+    },
+  };
+
+  test("parse basic config no crash", () => {
+    expect(() => {
+      parseOwnershipRules(basicConfig, null);
+    }).not.toThrow();
+  });
+
+  test("parse basic config has output", () => {
+    expect(parseOwnershipRules(basicConfig, null)).toBeDefined();
+  });
+
+  test("parse basic config to correct allow dot github content", () => {
+    const config = parseOwnershipRules(basicConfig, null);
+    expect(config.allowDotGitHub).toBeTruthy();
+  });
+
+  test("parse basic config to correct global blacklist", () => {
+    const config = parseOwnershipRules(basicConfig, null);
+    const correctBlacklistedUserCount = 2;
+    expect(config.globalBlacklistedUsers.length).toEqual(
+      correctBlacklistedUserCount,
+    );
+    expect(config.globalBlacklistedUsers).toContain("bad_user_1");
+    expect(config.globalBlacklistedUsers).toContain("bad_user_2");
   });
 });

--- a/src/utils/config_parser/parser.test.ts
+++ b/src/utils/config_parser/parser.test.ts
@@ -1,0 +1,21 @@
+import { parseOwnershipRules } from "./parser";
+
+describe("Configuration parser tests", () => {
+  test("parse basic config", () => {
+    expect(
+      parseOwnershipRules(
+        {
+          "ownership_rules": {
+            "directory_matching_rules": [
+              {
+                "name": "test_rule_0",
+                "path": "playground/{{username}}/*",
+              },
+            ],
+          },
+        },
+        null,
+      ),
+    ).toBeDefined();
+  });
+});

--- a/src/utils/config_parser/parser.ts
+++ b/src/utils/config_parser/parser.ts
@@ -22,6 +22,14 @@ export const parseOwnershipRules = (
         "allow_dot_github"
       ] as boolean;
     }
+    if ("global_blacklisted_users" in ownershipRulesData) {
+      const blacklistedUsernames: string[] = ownershipRulesData[
+        "global_blacklisted_users"
+      ] as string[];
+      blacklistedUsernames.forEach((blacklistedUsername) => {
+        ownershipRules.globalBlacklistedUsers.push(blacklistedUsername);
+      });
+    }
     if ("directory_matching_rules" in ownershipRulesData) {
       context?.log.info("Found directory_matching_rules in the config");
       for (const rule of ownershipRulesData[

--- a/src/utils/config_parser/parser.ts
+++ b/src/utils/config_parser/parser.ts
@@ -1,0 +1,45 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { DirectoryMatchingRule, OwnershipRules } from "../types";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Context } from "probot";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+import { getDefaultOwnershipRules } from "./default";
+
+export const parseOwnershipRules = (
+  rules: Record<string, unknown>,
+  context: Context | null,
+): OwnershipRules => {
+  const ownershipRules: OwnershipRules = getDefaultOwnershipRules(false);
+  if ("ownership_rules" in rules) {
+    context?.log.info("Found ownership_rules in the config");
+    const ownershipRulesData = rules["ownership_rules"] as Record<
+      string,
+      unknown
+    >;
+    if ("allow_dot_github" in ownershipRulesData) {
+      ownershipRules.allowDotGitHub = ownershipRulesData[
+        "allow_dot_github"
+      ] as boolean;
+    }
+    if ("directory_matching_rules" in ownershipRulesData) {
+      context?.log.info("Found directory_matching_rules in the config");
+      for (const rule of ownershipRulesData[
+        "directory_matching_rules"
+      ] as Record<string, string>[]) {
+        const directoryMatchingRule: DirectoryMatchingRule = {
+          name: "Default directory matching rule name",
+          path: "Undefined",
+        };
+        if ("name" in rule) {
+          directoryMatchingRule.name = rule["name"];
+        }
+        if ("path" in rule) {
+          directoryMatchingRule.path = rule["path"];
+        }
+        ownershipRules.directoryMatchingRules.push(directoryMatchingRule);
+      }
+    }
+  }
+  return ownershipRules;
+};

--- a/src/utils/health_check/index.test.ts
+++ b/src/utils/health_check/index.test.ts
@@ -3,7 +3,7 @@ import { healthCheck } from ".";
 
 describe("health check tests", () => {
   const defaultEnv = process.env;
-  const log: Logger = new Logger();
+  const log: Logger = new Logger({ minLevel: "error" });
 
   beforeEach(() => {
     // Clears the jest cache so that the environment will
@@ -44,7 +44,7 @@ describe("health check tests", () => {
           log.info(msg);
         },
         (msg) => {
-          log.error(msg);
+          expect(msg).toContain("GitHub Enterprise");
         },
       );
     }).toThrow();

--- a/src/utils/matchers/blacklist_user.test.ts
+++ b/src/utils/matchers/blacklist_user.test.ts
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { OwnershipRules } from "../types";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+import { isUserBlacklisted } from "./blacklist_user";
+
+describe("Blacklist user checker tests", () => {
+  const rules: OwnershipRules = {
+    allowDotGitHub: true,
+    directoryMatchingRules: [],
+    globalBlacklistedUsers: ["bad_user_1", "bad_user_2"],
+  };
+
+  test("should not crash", () => {
+    expect(() => {
+      isUserBlacklisted("good_user", rules);
+    }).not.toThrow();
+  });
+
+  test("should block bad users", () => {
+    expect(isUserBlacklisted("bad_user_1", rules)).toBeTruthy();
+  });
+
+  test("should allow good users", () => {
+    expect(isUserBlacklisted("good_user", rules)).toBeFalsy();
+  });
+});

--- a/src/utils/matchers/blacklist_user.ts
+++ b/src/utils/matchers/blacklist_user.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { OwnershipRules } from "../types";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+/**
+ * Checks if a user with [username] is blacklisted by the
+ * repository owner.
+ *
+ * @param username The username that triggers the run.
+ * @param rules The ownership rules defined by the repository owner.
+ */
+export const isUserBlacklisted = (
+  username: string,
+  rules: OwnershipRules,
+): boolean => {
+  const finder: string | undefined = rules.globalBlacklistedUsers.find(
+    (blacklistedUsername) => blacklistedUsername === username,
+  );
+  const isBlacklisted: boolean = finder !== undefined;
+  return isBlacklisted;
+};

--- a/src/utils/matchers/index.ts
+++ b/src/utils/matchers/index.ts
@@ -1,4 +1,5 @@
 import { containsNotAllowedFile } from "./blacklist_patterns";
+import { isUserBlacklisted } from "./blacklist_user";
 import { ownsAllFiles } from "./rule_matchers";
 
-export { ownsAllFiles, containsNotAllowedFile };
+export { ownsAllFiles, containsNotAllowedFile, isUserBlacklisted };

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -14,7 +14,7 @@ export interface OwnershipRules {
    * is safe, this is disabled by default.
    */
   allowDotGitHub: boolean;
-  globalBlacklistedUsers: UserInfo[];
+  globalBlacklistedUsers: string[];
   directoryMatchingRules: DirectoryMatchingRule[];
 }
 

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -14,6 +14,7 @@ export interface OwnershipRules {
    * is safe, this is disabled by default.
    */
   allowDotGitHub: boolean;
+  globalBlacklistedUsers: UserInfo[];
   directoryMatchingRules: DirectoryMatchingRule[];
 }
 

--- a/test/fixtures/config/basic.yml
+++ b/test/fixtures/config/basic.yml
@@ -1,4 +1,7 @@
 ownership_rules:
+  global_blacklisted_users:
+    - bad_user_1
+    - bad_user_2
   directory_matching_rules:
     - name: personal projects in playground
       path: playground/{{username}}/**/*

--- a/test/fixtures/payloads/blacklist_user/index.ts
+++ b/test/fixtures/payloads/blacklist_user/index.ts
@@ -1,0 +1,25 @@
+import prFromBlacklistedUser from "./pr.json";
+
+const prFromBlacklistedUserOpenedPayload: Record<
+  string,
+  unknown
+> = Object.assign({}, prFromBlacklistedUser) as Record<string, unknown>;
+prFromBlacklistedUserOpenedPayload["action"] = "opened";
+
+const prFromBlacklistedUserReopenedPayload: Record<
+  string,
+  unknown
+> = Object.assign({}, prFromBlacklistedUser) as Record<string, unknown>;
+prFromBlacklistedUserReopenedPayload["action"] = "reopened";
+
+const prFromBlacklistedUserSynchronizePayload: Record<
+  string,
+  unknown
+> = Object.assign({}, prFromBlacklistedUser) as Record<string, unknown>;
+prFromBlacklistedUserSynchronizePayload["action"] = "synchronize";
+
+export {
+  prFromBlacklistedUserOpenedPayload,
+  prFromBlacklistedUserReopenedPayload,
+  prFromBlacklistedUserSynchronizePayload,
+};

--- a/test/fixtures/payloads/blacklist_user/pr.json
+++ b/test/fixtures/payloads/blacklist_user/pr.json
@@ -1,0 +1,25 @@
+{
+  "number": 1,
+  "pull_request": {
+    "user": {
+      "login": "bad_user_1"
+    },
+    "head": {
+      "sha": "fake_sha"
+    },
+    "body": "",
+    "number": 1,
+    "draft": false
+  },
+  "repository": {
+    "name": "approveman-test",
+    "full_name": "tianhaoz95/approveman-test",
+    "private": false,
+    "owner": {
+      "login": "tianhaoz95"
+    }
+  },
+  "sender": {
+    "login": "bad_user_1"
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,6 +11,11 @@ import {
   checkSuccessStatus,
 } from "./utils/status";
 import {
+  prFromBlacklistedUserOpenedPayload,
+  prFromBlacklistedUserReopenedPayload,
+  prFromBlacklistedUserSynchronizePayload,
+} from "./fixtures/payloads/blacklist_user";
+import {
   prOpenedPayload,
   prReopenedPayload,
   prSynchronizePayload,
@@ -156,6 +161,57 @@ describe("Approveman tests", () => {
       id: "test_id",
       name: "pull_request",
       payload: prOpenedPayload,
+    });
+  });
+
+  test("blocks pr opened by globally blacklisted user", async () => {
+    setConfigToBasic("basic");
+    checkNeutralStatus();
+    setPullRequestFiles([
+      "some/random/file.md",
+      "playground/tianhaoz95/README.md",
+      "playground/tianhaoz95/development.md",
+    ]);
+    setSinglePreviousReview();
+    verifyReviewDismissed();
+    await probot.receive({
+      id: "test_id",
+      name: "pull_request",
+      payload: prFromBlacklistedUserOpenedPayload,
+    });
+  });
+
+  test("blocks pr reopened by globally blacklisted user", async () => {
+    setConfigToBasic("basic");
+    checkNeutralStatus();
+    setPullRequestFiles([
+      "some/random/file.md",
+      "playground/tianhaoz95/README.md",
+      "playground/tianhaoz95/development.md",
+    ]);
+    setSinglePreviousReview();
+    verifyReviewDismissed();
+    await probot.receive({
+      id: "test_id",
+      name: "pull_request",
+      payload: prFromBlacklistedUserReopenedPayload,
+    });
+  });
+
+  test("blocks pr sync by globally blacklisted user", async () => {
+    setConfigToBasic("basic");
+    checkNeutralStatus();
+    setPullRequestFiles([
+      "some/random/file.md",
+      "playground/tianhaoz95/README.md",
+      "playground/tianhaoz95/development.md",
+    ]);
+    setSinglePreviousReview();
+    verifyReviewDismissed();
+    await probot.receive({
+      id: "test_id",
+      name: "pull_request",
+      payload: prFromBlacklistedUserSynchronizePayload,
     });
   });
 


### PR DESCRIPTION
This PR adds the capability for repository owners to set a list of globally blacklisted usernames. This can be useful when certain users are spotted to abuse the automatic approval process and checks in unwanted content that violates policies set by the owner. In the future, a whitelisting capability is planned for people who want to keep the authorized user within the team.