### PR TITLE
feat: Support user allowlist, as per #153

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -114,6 +114,14 @@ ownership_rules:
   # the auto approval and checks in unwanted content that violates the code of
   # conduct or other policies set by the owner.
   global_blacklisted_users: []
+  # An optional list of usernames that should get their pull requests approved if
+  # validated by rules. This can be used when only some users are trusted "commit
+  # directly to the default branch", but you still want repository checks to be run for
+  # their changes.  If not specified or empty, all users are considered to be "allowed".
+  # This is also useful for automation usecases, automatically approving PRs created by
+  # specific machine users.
+  # N.B. Where a user is both "allowed" and "blacklisted", blacklisting takes precedence.
+  global_allowed_users: []
   # The rules for matching directory ownership. A pull request is determined to be safe
   # when all the files modified satisfy at least one of the rules.
   directory_matching_rules:

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,6 @@
 import {
   containsNotAllowedFile,
+  isUserAllowed,
   isUserBlacklisted,
   ownsAllFiles,
 } from "../utils/matchers";
@@ -39,8 +40,8 @@ export const maybeApproveChange = async (context: Context<"pull_request.opened" 
     // TODO(tianhaoz95): consolidate there precondition checks into
     // a separate file with name check_prerequisites.ts to make it
     // more readable.
-    if (isUserBlacklisted(userInfo.username, rules)) {
-      context.log.trace("The user is blacklisted.");
+    if (isUserBlacklisted(userInfo.username, rules) || !isUserAllowed(userInfo.username, rules)) {
+      context.log.trace("The user is not approved.");
       await dismissAllApprovals(context);
       context.log.trace("All previous approvals dismissed");
       // TODO(tianhaoz95): consider making this a failing check

--- a/src/utils/config_parser/default.ts
+++ b/src/utils/config_parser/default.ts
@@ -8,6 +8,7 @@ export const getDefaultOwnershipRules = (
   const ownershipRules: OwnershipRules = {
     allowDotGitHub: false,
     directoryMatchingRules: [],
+    globalAllowedUsers: [],
     globalBlacklistedUsers: [],
   };
   if (addPlayground) {

--- a/src/utils/config_parser/parser.test.ts
+++ b/src/utils/config_parser/parser.test.ts
@@ -17,6 +17,7 @@ describe("Configuration parser tests", () => {
           "path": "test_1/{{username}}/*",
         },
       ],
+      "global_allowed_users": ["good_user_1", "good_user_2", "bad_user_2"],
       "global_blacklisted_users": ["bad_user_1", "bad_user_2"],
     },
   };
@@ -44,5 +45,16 @@ describe("Configuration parser tests", () => {
     );
     expect(config.globalBlacklistedUsers).toContain("bad_user_1");
     expect(config.globalBlacklistedUsers).toContain("bad_user_2");
+  });
+
+  test("parse basic config to correct global allow list", () => {
+    const config = parseOwnershipRules(basicConfig, null);
+    const correctAllowedUserCount = 3;
+    expect(config.globalAllowedUsers.length).toEqual(
+      correctAllowedUserCount,
+    );
+    expect(config.globalAllowedUsers).toContain("good_user_1");
+    expect(config.globalAllowedUsers).toContain("good_user_2");
+    expect(config.globalAllowedUsers).toContain("bad_user_2");
   });
 });

--- a/src/utils/config_parser/parser.ts
+++ b/src/utils/config_parser/parser.ts
@@ -22,6 +22,14 @@ export const parseOwnershipRules = (
         "allow_dot_github"
       ] as boolean;
     }
+    if ("global_allowed_users" in ownershipRulesData) {
+      const allowedUsernames: string[] = ownershipRulesData[
+        "global_allowed_users"
+      ] as string[];
+      allowedUsernames.forEach((allowedUsername) => {
+        ownershipRules.globalAllowedUsers.push(allowedUsername);
+      });
+    }
     if ("global_blacklisted_users" in ownershipRulesData) {
       const blacklistedUsernames: string[] = ownershipRulesData[
         "global_blacklisted_users"

--- a/src/utils/matchers/allowed_user.test.ts
+++ b/src/utils/matchers/allowed_user.test.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { OwnershipRules } from "../types";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+import { isUserAllowed } from "./allowed_user";
+
+describe("Specified allowed user checker tests", () => {
+  const rules: OwnershipRules = {
+    allowDotGitHub: true,
+    directoryMatchingRules: [],
+    globalAllowedUsers: ["good_user_1", "good_user_2", "bad_user_2"],
+    globalBlacklistedUsers: [],
+  };
+
+  test("should not crash", () => {
+    expect(() => {
+      isUserAllowed("unknown_user", rules);
+    }).not.toThrow();
+  });
+
+  test("should block unknown users", () => {
+    expect(isUserAllowed("unknown_user", rules)).toBeFalsy();
+  });
+
+  test("should allow good users", () => {
+    expect(isUserAllowed("good_user_1", rules)).toBeTruthy();
+  });
+});
+
+describe("No allowed user checker tests", () => {
+  const rules: OwnershipRules = {
+    allowDotGitHub: true,
+    directoryMatchingRules: [],
+    globalAllowedUsers: [],
+    globalBlacklistedUsers: [],
+  };
+
+  test("should not crash", () => {
+    expect(() => {
+      isUserAllowed("unknown_user", rules);
+    }).not.toThrow();
+  });
+
+  test("should allow all users", () => {
+    expect(isUserAllowed("unknown_user", rules)).toBeTruthy();
+  });
+});

--- a/src/utils/matchers/allowed_user.ts
+++ b/src/utils/matchers/allowed_user.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { OwnershipRules } from "../types";
+/* eslint-enable @typescript-eslint/no-unused-vars */
+
+/**
+ * Checks if a user with [username] is allowed by the
+ * repository owner.
+ *
+ * @param username The username that triggers the run.
+ * @param rules The ownership rules defined by the repository owner.
+ */
+export const isUserAllowed = (
+  username: string,
+  rules: OwnershipRules,
+): boolean => {
+  const isAllowed: boolean = (
+    !rules.globalAllowedUsers.length
+  ) || rules.globalAllowedUsers.some(
+    (allowedUsername) => allowedUsername === username,
+  );
+  return isAllowed;
+};

--- a/src/utils/matchers/blacklist_user.test.ts
+++ b/src/utils/matchers/blacklist_user.test.ts
@@ -7,6 +7,7 @@ describe("Blacklist user checker tests", () => {
   const rules: OwnershipRules = {
     allowDotGitHub: true,
     directoryMatchingRules: [],
+    globalAllowedUsers: [],
     globalBlacklistedUsers: ["bad_user_1", "bad_user_2"],
   };
 

--- a/src/utils/matchers/index.ts
+++ b/src/utils/matchers/index.ts
@@ -1,5 +1,6 @@
 import { containsNotAllowedFile } from "./blacklist_patterns";
+import { isUserAllowed } from "./allowed_user";
 import { isUserBlacklisted } from "./blacklist_user";
 import { ownsAllFiles } from "./rule_matchers";
 
-export { ownsAllFiles, containsNotAllowedFile, isUserBlacklisted };
+export { ownsAllFiles, containsNotAllowedFile, isUserAllowed, isUserBlacklisted };

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -14,6 +14,7 @@ export interface OwnershipRules {
    * is safe, this is disabled by default.
    */
   allowDotGitHub: boolean;
+  globalAllowedUsers: string[];
   globalBlacklistedUsers: string[];
   directoryMatchingRules: DirectoryMatchingRule[];
 }


### PR DESCRIPTION
Prior to this change, users could be explicitly disallowed, providing
for the case where most users with access to the repository could
benefit from auto-approval, but not all.  However, there are at least a
couple of use-cases where many people have access to a repo, with the
specific set of people changing over time, but only a limited and
consistent set of users should have their PRs auto-approved. Such cases
include:
* Sub-admin super-users who are permitted to make changes to specific
  files without oversight, but with repository checks still applied.
* Machine Users that commit back to the repository as part of a CI/CD
  pipeline without human oversight in the general case; repository
  checks and directory matching rules are used to detect bad actors and
  leave PRs unmerged for human oversight.

This change adds a new optional configuration field to support the
specification of explicitly allowed users.  When not provided or left
empty, the existing behaviour prevails: All users are allowed, unless
blacklisted.  When provided, on the other hand, only the given users are
allowed (effectively blacklisting everyone _else_).  Finally, where the
same user is specified in both the new configuration and a blacklist,
the blacklist takes preecedence and the user is blocked.

Closes #153